### PR TITLE
Fix bugs with the class limiting

### DIFF
--- a/addons/sourcemod/scripting/nt_classlimit.sp
+++ b/addons/sourcemod/scripting/nt_classlimit.sp
@@ -200,6 +200,12 @@ public MRESReturn PfnHook_LeaveState_PickingLoadout(int client)
 
 public void OnClientPutInServer(int client)
 {
+	// Has to be a real client because the classes differ
+	if (IsFakeClient(client))
+	{
+		return;
+	}
+
 	if (!g_dd_Pfn)
 	{
 		HookClassSelectionPfns(client);
@@ -410,11 +416,15 @@ int GetNumPlayersOfClassInTeam(int class, int team)
 		{
 			continue;
 		}
-		if (!IsPlayerAlive(client))
+		if (GetPlayerClass(client) != class)
 		{
 			continue;
 		}
-		if (GetPlayerClass(client) != class)
+		// Consider someone who's chosen the class and is currently in the
+		// loadout selection screen as having reserved the right to spawn
+		// with this class.
+		if (!IsPlayerAlive(client) &&
+			g_e_PlayerState[client] != STATE_PICKINGLOADOUT)
 		{
 			continue;
 		}

--- a/addons/sourcemod/scripting/nt_classlimit.sp
+++ b/addons/sourcemod/scripting/nt_classlimit.sp
@@ -6,19 +6,54 @@
 #pragma semicolon 1
 #pragma newdecls required
 
-#define STATE_PICKINGCLASS 3
+enum PlayerState {
+	STATE_UNKNOWN = 0,
+	STATE_INTRO,
+	STATE_PICKINGTEAM,
+	STATE_PICKINGCLASS,
+	STATE_PICKINGLOADOUT,
+	STATE_PLAYERDEATH,
+	STATE_DEAD,
+	STATE_OBSERVERMODE,
+
+	STATE_MAX_VALUE = STATE_OBSERVERMODE
+};
+
+enum PlayerStatePfn {
+	PFN_ENTER_STATE = 0,
+	PFN_LEAVE_STATE,
+
+	PFN_ENUM_COUNT
+};
+/*	PlayerStateInfo memory layout:
+	0	CPlayerState m_iPlayerState;
+	4	const char *m_pStateName;
+
+	8	void (CPlayer::*pfnEnterState)();
+	24	void (CPlayer::*pfnLeaveState)();
+
+	40	void (CPlayer::*pfnPreThink)();
+	56
+*/
+int g_i_PfnOffsets[PFN_ENUM_COUNT] = { 8, 24 };
+
+char g_s_PluginTag[] = "[CLASS-LIMITS]";
+
+ConVar g_Cvar_MaxRecons, g_Cvar_MaxAssaults, g_Cvar_MaxSupports;
+
+DynamicDetour g_dd_Pfn = null;
+DHookCallback g_PfnCbIds[PFN_ENUM_COUNT] = { INVALID_FUNCTION, ... };
+HookMode g_pfnHookMode = Hook_Pre;
+
+PlayerState g_e_PlayerState[NEO_MAXPLAYERS + 1] = { STATE_UNKNOWN, ... };
 
 public Plugin myinfo = {
 	name		= "Neotokyo Class Limits",
 	author		= "kinoko, rain",
 	description	= "Enables allowing class limits for competitive play without the need for manual tracking",
-	version		= "1.0.0",
+	version		= "1.0.1",
 	url			= "https://github.com/kassibuss/nt_classlimit"
 };
-
-ConVar g_Cvar_MaxRecons, g_Cvar_MaxAssaults, g_Cvar_MaxSupports;
-
-char g_s_PluginTag[] = "[CLASS-LIMITS]";
 
 public void OnPluginStart()
 {
@@ -55,8 +90,120 @@ public void OnPluginStart()
 		SetFailState("Failed to hook event");
 	}
 
+	for (int client = 1; client <= MaxClients; ++client)
+	{
+		if (!IsClientInGame(client) || IsFakeClient(client))
+		{
+			continue;
+		}
+		HookClassSelectionPfns(client);
+		break;
+	}
+
 	// Create the default config file, if it doesn't exist yet
 	AutoExecConfig();
+}
+
+void HookClassSelectionPfns(int client)
+{
+	HookPlayerState(client, STATE_PICKINGCLASS, PFN_ENTER_STATE,
+		PfnHook_EnterState_PickingClass);
+	HookPlayerState(client, STATE_PICKINGLOADOUT, PFN_ENTER_STATE,
+		PfnHook_EnterState_PickingLoadout);
+	HookPlayerState(client, STATE_PICKINGLOADOUT, PFN_LEAVE_STATE,
+		PfnHook_LeaveState_PickingLoadout);
+}
+
+void CallPlayerStatePfn(int client, PlayerState state, PlayerStatePfn pfn)
+{
+	Address fn = GetPfn(client, state, pfn);
+	if (fn == Address_Null)
+	{
+		return;
+	}
+	StartPrepSDKCall(SDKCall_Player);
+	PrepSDKCall_SetAddress(fn);
+	Handle call = EndPrepSDKCall();
+	if (call == INVALID_HANDLE)
+	{
+		ThrowError("Failed to prepare SDK call for (%d, %d)", state, pfn);
+	}
+	SDKCall(call, client);
+	CloseHandle(call);
+}
+
+Address GetPfn(int client, PlayerState state, PlayerStatePfn pfn)
+{
+	Address base = State_LookupInfo(client, state);
+	if (base == Address_Null)
+	{
+		ThrowError("Player state base address was null");
+	}
+	int offset = g_i_PfnOffsets[pfn];
+	Address address = base + view_as<Address>(offset);
+	return LoadFromAddress(address, NumberType_Int32);
+}
+
+void HookPlayerState(int client, PlayerState state, PlayerStatePfn pfn,
+	DHookCallback cb)
+{
+	// only need to hook once
+	if (g_PfnCbIds[pfn] != INVALID_FUNCTION)
+	{
+		return;
+	}
+
+	Address fn = GetPfn(client, state, pfn);
+	// note that this is not an error; the function pointer can be null
+	if (fn == Address_Null)
+	{
+		return;
+	}
+
+	if (!g_dd_Pfn)
+	{
+		g_dd_Pfn = DHookCreateDetour(fn, CallConv_THISCALL, ReturnType_Void,
+			ThisPointer_CBaseEntity);
+		if (!g_dd_Pfn)
+		{
+			ThrowError("Failed to create detour for pfn %d", pfn);
+		}
+	}
+
+	if (!g_dd_Pfn.Enable(g_pfnHookMode, cb))
+	{
+		ThrowError("Failed to detour pfn %d", pfn);
+	}
+
+	g_PfnCbIds[pfn] = cb;
+}
+
+public MRESReturn PfnHook_EnterState_PickingClass(int client)
+{
+	g_e_PlayerState[client] = STATE_PICKINGCLASS;
+	return MRES_Ignored;
+}
+
+public MRESReturn PfnHook_EnterState_PickingLoadout(int client)
+{
+	g_e_PlayerState[client] = STATE_PICKINGLOADOUT;
+	return MRES_Ignored;
+}
+
+public MRESReturn PfnHook_LeaveState_PickingLoadout(int client)
+{
+	// just labeling any other state as "unknown", since we're not interested
+	// in keeping track of it
+	g_e_PlayerState[client] = STATE_UNKNOWN;
+	return MRES_Ignored;
+}
+
+public void OnClientPutInServer(int client)
+{
+	if (!g_dd_Pfn)
+	{
+		HookClassSelectionPfns(client);
+	}
 }
 
 public void OnRoundStart(Event event, const char[] name, bool dontBroadcast)
@@ -73,12 +220,17 @@ public void OnRoundStart(Event event, const char[] name, bool dontBroadcast)
 		// round class selection.
 		if (GetClientTeam(client) > TEAM_SPECTATOR)
 		{
-			int fallback_class = GetAllowedClass(client);
-			if (fallback_class != CLASS_NONE)
+			if (g_e_PlayerState[client] == STATE_PICKINGLOADOUT)
 			{
-				SetPlayerClass(client, fallback_class);
+				int fallback_class = GetAllowedClass(client);
+				if (fallback_class != CLASS_NONE)
+				{
+					SetPlayerClass(client, fallback_class);
+					CallPlayerStatePfn(client, STATE_PICKINGCLASS,
+						PFN_ENTER_STATE);
+					ClientCommand(client, "playerstate_reverse");
+				}
 			}
-			ClientCommand(client, "playerstate_reverse");
 		}
 	}
 }
@@ -93,44 +245,48 @@ public MRESReturn Detour_PlayerReady(DHookReturn hReturn, DHookParam hParams)
 		return MRES_Ignored;
 	}
 
-	// Can't respawn with different class once already spawned in the world
+	// Already spawned in the world
 	if (IsPlayerAlive(client))
 	{
-		hReturn.Value = false;
-		return MRES_Supercede;
+		return MRES_Ignored;
 	}
 
-	if (!IsClassAllowed(client, GetPlayerClass(client)))
+	if (IsClassAllowed(client, GetPlayerClass(client)))
 	{
-		// If this class was not allowed, see if there's any available class
-		int fallback_class = GetAllowedClass(client);
-
-		// If all the classes are full, just allow the player to spawn.
-		// This is necessary because otherwise
-		// this client would eventually spawn with no class, in a bugged state.
-		// Another alternative would be to forcibly yeet them to spectator,
-		// but this could be problematic in itself for competitive play due to
-		// possible ghosting.
-		// This can only happen if the sum of (sm_maxrecons + sm_maxassaults + sm_maxsupports)
-		// cvars is less than the number of players in a player team (Jin or NSF).
-		if (fallback_class == CLASS_NONE)
-		{
-			return MRES_Ignored;
-		}
-
-		// If there was a class available, force it as the player's default class.
-		// This prevents a stubborn player from spawning with a forbidden class
-		// if they just opt to wait out the max. spawn selection time without
-		// choosing another class.
-		SetPlayerClass(client, fallback_class);
-
-		// Rewind the player state & prevent this spawn sequence from happening
-		SetPlayerState(client, STATE_PICKINGCLASS);
-		hReturn.Value = false;
-		return MRES_Supercede;
+		return MRES_Ignored;
 	}
 
-	return MRES_Ignored;
+	// If this class was not allowed, see if there's any available class
+	int fallback_class = GetAllowedClass(client);
+
+	// If all the classes are full, just allow the player to spawn.
+	// This is necessary because otherwise
+	// this client would eventually spawn with no class, in a bugged state.
+	// Another alternative would be to forcibly yeet them to spectator,
+	// but this could be problematic in itself for competitive play due to
+	// possible ghosting.
+	// This can only happen if the sum of (sm_maxrecons + sm_maxassaults + sm_maxsupports)
+	// cvars is less than the number of players in a player team (Jin or NSF).
+	if (fallback_class == CLASS_NONE)
+	{
+		return MRES_Ignored;
+	}
+
+	if (g_e_PlayerState[client] != STATE_PICKINGLOADOUT)
+	{
+		return MRES_Ignored;
+	}
+
+	// If there was a class available, force it as the player's default class.
+	// This prevents a stubborn player from spawning with a forbidden class
+	// if they just opt to wait out the max. spawn selection time without
+	// choosing another class.
+	SetPlayerClass(client, fallback_class);
+
+	ClientCommand(client, "playerstate_reverse");
+
+	hReturn.Value = false;
+	return MRES_Supercede;
 }
 
 int GetAllowedClass(int client)
@@ -148,14 +304,16 @@ int GetAllowedClass(int client)
 	// are allowed per class, but there's more than 3*5 players, the 16th player
 	// would have no valid class left. This is not a plugin bug per se, but rather
 	// a server misconfiguration regarding the abovementioned cvar limits.
+	//
 	// TLDR: the sum of the 3 cvars should *always* be >= expected number of players
 	// in a playable team (Jinrai or NSF).
 	PrintToChatAll("%s WARNING: all class limits are exhausted!", g_s_PluginTag);
+	PrintToChatAll("This is a server config error. Allowing all classes to spawn.");
 
 	return CLASS_NONE;
 }
 
-void SetPlayerState(int client, int state)
+Address State_LookupInfo(int client, PlayerState state)
 {
 	static Handle call = INVALID_HANDLE;
 	if (call == INVALID_HANDLE)
@@ -163,17 +321,19 @@ void SetPlayerState(int client, int state)
 		StartPrepSDKCall(SDKCall_Player);
 		PrepSDKCall_SetSignature(
 			SDKLibrary_Server,
-			"\x56\x8B\xF1\x8B\x86\x68\x0E\x00\x00",
-			9
+			"\xF6\x05\x2A\x2A\x2A\x2A\x01\x0F\x85\x2A\x2A\x2A\x2A\xB8\x2A\x2A\x2A\x2A",
+			18
 		);
 		PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_Plain);
+		PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);
 		call = EndPrepSDKCall();
 		if (call == INVALID_HANDLE)
 		{
 			SetFailState("Failed to prepare SDK call");
 		}
 	}
-	SDKCall(call, client, state);
+
+	return SDKCall(call, client, view_as<int>(state));
 }
 
 public Action Cmd_OnClass(int client, const char[] command, int argc)
@@ -194,7 +354,9 @@ public Action Cmd_OnClass(int client, const char[] command, int argc)
 	{
 		PrintToChat(client, "%s Please select another class", g_s_PluginTag);
 		PrintCenterText(client, "- CLASS IS FULL -");
+
 		ClientCommand(client, "classmenu");
+
 		return Plugin_Handled;
 	}
 


### PR DESCRIPTION
This should fix the bug that boots players out of their team.

Also a pretty big rework of the overall logic. Should probably revisit to comment the changes properly, but give it a try.

There's a known issue still present where someone who just sits idle until the game force-spawns them in the level is able to bypass the class restrictions, since they never technically chose a class.